### PR TITLE
focusing on the key when an object property is added

### DIFF
--- a/build/jquery.json-editor.js
+++ b/build/jquery.json-editor.js
@@ -529,7 +529,7 @@
           }
           innerbq.append($('<span class="colon">: </span>'));
           newElem = this.build(jsonvalue, innerbq, json, jsonkey, root);
-          if (newElem && newElem.text() === "??") {
+          if (!elem && newElem && newElem.text() === "??") {
             elem = newElem;
           }
           bq.append(innerbq);

--- a/lib/js/jquery.json-editor.js.coffee
+++ b/lib/js/jquery.json-editor.js.coffee
@@ -224,7 +224,6 @@ class window.JSONEditor
     @setJsonFromText()
     @alreadyFocused = false
     elem = @build(@json, @builder, null, null, @json)
-
     @recoverScrollPosition()
 
     # Auto-focus to edit '??' keys and values.
@@ -409,7 +408,7 @@ class window.JSONEditor
 
         innerbq.append($('<span class="colon">: </span>'))
         newElem = @build(jsonvalue, innerbq, json, jsonkey, root)
-        elem = newElem if newElem && newElem.text() == "??"
+        elem = newElem if !elem && newElem && newElem.text() == "??"
         bq.append(innerbq)
 
       bq.prepend(@addUI(json))

--- a/spec/compiled/core-spec.js
+++ b/spec/compiled/core-spec.js
@@ -26,10 +26,16 @@
       j.setJsonFromText();
       return expect(j.json['hello']).toEqual("world");
     });
-    return it("should allow return and tab in text", function() {
+    it("should allow return and tab in text", function() {
       var j;
       j = new JSONEditor($("#t_returns_and_tabs"));
       return expect(j.json['hello']).toEqual('wo\\nr\\tld');
+    });
+    return it("should focus on the key when an object property is added", function() {
+      var j;
+      j = new JSONEditor($("#t_empty1"));
+      $('[title="add"]').click();
+      return expect($('.key .edit_field').is(':focus')).toEqual(true);
     });
   });
 

--- a/spec/core-spec.js.coffee
+++ b/spec/core-spec.js.coffee
@@ -40,3 +40,9 @@ describe "basic functionality", ->
   it "should allow return and tab in text", ->
     j = new JSONEditor($("#t_returns_and_tabs"))
     expect(j.json['hello']).toEqual 'wo\\nr\\tld'
+
+  it "should focus on the key when an object property is added", ->
+    j = new JSONEditor($("#t_empty1"))
+    $('[title="add"]').click()
+    expect($('.key .edit_field').is(':focus')).toEqual(true)
+


### PR DESCRIPTION
This issue was annoying me when using Huginn so I created this patch.

The only problem is I can't get the test to work (although it's clearly working when testing manually).
Any ideas on how to fix this test? Jasmine apparently can't recognise which element is focused as document.activeElement returns the body tag after the click event is triggered.

Thanks
