### PR TITLE
Display null values as empty strings

### DIFF
--- a/build/jquery.json-editor.js
+++ b/build/jquery.json-editor.js
@@ -544,6 +544,9 @@
         bq.append($('<div class="bracers">}</div>'));
         node.append(bq);
       } else {
+        if (json === null) {
+          json = '';
+        }
         elem = this.editable(json.toString(), key, parent, root, 'value').wrap('<span class="val"></span>').parent();
         node.append(elem);
         node.prepend(this.braceUI(key, parent));

--- a/lib/js/jquery.json-editor.js.coffee
+++ b/lib/js/jquery.json-editor.js.coffee
@@ -419,6 +419,8 @@ class window.JSONEditor
       bq.append($('<div class="bracers">}</div>'))
       node.append(bq)
     else
+      if json == null
+        json = ''
       elem = @editable(json.toString(), key, parent, root, 'value').wrap('<span class="val"></span>').parent();
       node.append(elem)
       node.prepend(@braceUI(key, parent))

--- a/spec/compiled/core-spec.js
+++ b/spec/compiled/core-spec.js
@@ -2,7 +2,7 @@
 
   describe("basic functionality", function() {
     beforeEach(function() {
-      return $("#jasmine_content").html("<textarea id=\"t\">\n  {\n    \"name\": \"a.title\",\n    \"description\": \"foo.bar\",\n    \"authors\": [{\n      \"name\": \"p.foo\",\n      \"link\": \"a | @href\"\n    }]\n  }\n</textarea>\n\n<textarea id=\"t_empty1\">{}</textarea>\n<textarea id=\"t_empty2\">{}</textarea>\n<textarea id=\"t_returns_and_tabs\">{\"hello\": \"wo\\nr\\tld\"}</textarea>");
+      return $("#jasmine_content").html("<textarea id=\"t\">\n  {\n    \"name\": \"a.title\",\n    \"description\": \"foo.bar\",\n    \"authors\": [{\n      \"name\": \"p.foo\",\n      \"link\": \"a | @href\"\n    }]\n  }\n</textarea>\n\n<textarea id=\"t_empty1\">{}</textarea>\n<textarea id=\"t_empty2\">{}</textarea>\n<textarea id=\"t_returns_and_tabs\">{\"hello\": \"wo\\nr\\tld\"}</textarea>\n<textarea id=\"t_null\">\n  {\n    \"null\": null\n  }\n</textarea>");
     });
     it("should load from a text area", function() {
       var j;
@@ -31,11 +31,17 @@
       j = new JSONEditor($("#t_returns_and_tabs"));
       return expect(j.json['hello']).toEqual('wo\\nr\\tld');
     });
-    return it("should focus on the key when an object property is added", function() {
+    it("should focus on the key when an object property is added", function() {
       var j;
       j = new JSONEditor($("#t_empty1"));
       $('[title="add"]').click();
       return expect($('.key .edit_field').is(':focus')).toEqual(true);
+    });
+    return it("should handle null values without exceptions", function() {
+      var j;
+      j = new JSONEditor($("#t_null"));
+      console.log(j.getJSON());
+      return expect(j.getJSON()['null']).toEqual(null);
     });
   });
 

--- a/spec/core-spec.js.coffee
+++ b/spec/core-spec.js.coffee
@@ -15,6 +15,11 @@ describe "basic functionality", ->
       <textarea id="t_empty1">{}</textarea>
       <textarea id="t_empty2">{}</textarea>
       <textarea id="t_returns_and_tabs">{"hello": "wo\\nr\\tld"}</textarea>
+      <textarea id="t_null">
+        {
+          "null": null
+        }
+      </textarea>
     """
 
   it "should load from a text area", ->
@@ -46,3 +51,7 @@ describe "basic functionality", ->
     $('[title="add"]').click()
     expect($('.key .edit_field').is(':focus')).toEqual(true)
 
+  it "should handle null values without exceptions", ->
+    j = new JSONEditor($("#t_null"))
+    console.log(j.getJSON())
+    expect(j.getJSON()['null']).toEqual null


### PR DESCRIPTION
Previously `json.toString()` raised an exception because `null` does not respond to `toString`.
I noticed this problem when dry-running Huginn Agents with JSON payload that was received from an external source and included some `null` values.